### PR TITLE
Reduced time to clone

### DIFF
--- a/src/esp_docs/idf_extensions/gen_version_specific_includes.py
+++ b/src/esp_docs/idf_extensions/gen_version_specific_includes.py
@@ -151,9 +151,9 @@ def write_git_clone_inc_files(templates, out_dir, version, ver_type, is_stable):
         return p
 
     if version == 'master':
-        clone_args = ''
+        clone_args = '--depth 1'
     else:
-        clone_args = '-b %s ' % version
+        clone_args = '-b %s --depth 1' % version
 
     with open(out_file('git-clone-bash'), 'w', encoding='utf-8') as f:
         f.write(templates['git-clone-bash'] % locals())


### PR DESCRIPTION
The git clone can be sped up substantially by skipping the commit history, using the "--depth 1" option.
Anyone who actually *wants* the commit history can get it with "git pull" or by looking online.