### PR TITLE
add GitHub GITHUB_REF_NAME variable for naming

### DIFF
--- a/src/esp_docs/deploy_docs.py
+++ b/src/esp_docs/deploy_docs.py
@@ -41,11 +41,8 @@ def env(variable, default=None):
 def main():
     # if you get KeyErrors on the following lines, it's probably because you're not running in Gitlab CI
     git_ver = env('GIT_VER')  # output of git describe --always
-    ci_ver = env('CI_COMMIT_REF_NAME', git_ver)  # branch or tag we're building for (used for 'release' & URL)
-
-    version = sanitize_version(ci_ver)
+    version = sanitize_version(git_ver) # branch or tag we're building for (used for 'release' & URL)
     print('Git version: {}'.format(git_ver))
-    print('CI Version: {}'.format(ci_ver))
     print('Deployment version: {}'.format(version))
 
     if not version:

--- a/src/esp_docs/deploy_docs.py
+++ b/src/esp_docs/deploy_docs.py
@@ -20,20 +20,22 @@
 import glob
 import os
 import os.path
+import packaging.version
 import re
 import stat
 import subprocess
+import sys
 import tarfile
 
-import packaging.version
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(SCRIPT_DIR))
+from sanitize_version import sanitize_version  # noqa
 
 
 def env(variable, default=None):
     """ Shortcut to return the expanded version of an environment variable """
     return os.path.expandvars(os.environ.get(variable, default) if default else os.environ[variable])
-
-
-from .sanitize_version import sanitize_version  # noqa
 
 
 def main():

--- a/src/esp_docs/sanitize_version.py
+++ b/src/esp_docs/sanitize_version.py
@@ -23,16 +23,16 @@ def sanitize_version(original_version):
     a URL-safe sanitized version. (this is used as 'release' config variable when building
     the docs.)
 
-    Will override the original version with the Gitlab CI CI_COMMIT_REF_NAME environment variable if
-    this is present.
+    Will override the original version with Gitlab or GitHub CI predefined variables
 
     Also follows the RTD-ism that master branch is named 'latest'
 
     """
 
-    try:
-        version = os.environ['CI_COMMIT_REF_NAME']
-    except KeyError:
+    version = os.environ.get('CI_COMMIT_REF_NAME')
+    if version is None:
+        version = os.environ.get('GITHUB_REF_NAME')
+    if version is None:
         version = original_version
 
     latest_branch_name = os.environ.get('ESP_DOCS_LATEST_BRANCH_NAME', 'master')


### PR DESCRIPTION
See https://github.com/espressif/esp-protocols/actions/runs/4499634763/jobs/7917794334 

The `ee8dea9` part of the path `mdns/ee8dea9/en/index.html...` should be tag or branch name

`ci_ver = env('CI_COMMIT_REF_NAME', git_ver)` variable has been removed as unused and unneeded 