### PR TITLE
fix: local substring substitution regex match

### DIFF
--- a/src/esp_docs/esp_extensions/format_esp_target.py
+++ b/src/esp_docs/esp_extensions/format_esp_target.py
@@ -166,7 +166,7 @@ class StringSubstituter:
                 # There should always be a default value
                 raise ValueError('No default value in IDF_TARGET_X substitution define, val={}'.format(sub_def))
 
-            match_target = re.match(r'^.*{}(\s*)=(\s*)\"(.*?)\"'.format(self.target_name), sub_def[1])
+            match_target = re.match(r'^.*{}\b(.*?)=(\s*)\"(.*?)\"'.format(self.target_name), sub_def[1])
 
             if match_target is None:
                 sub_value = match_default.groups()[2]


### PR DESCRIPTION
The regex used for matching the patterns for local substring substitution does not match the specified target in some parts of the ESP-IDF docs build. Actual text rendering on the docs site is still using the "default" field from the custom macros, rather than using target-specific ones.

For example in the [secure boot documentation](https://github.com/espressif/esp-idf/blob/master/docs/en/security/secure-boot-v2.rst#secure-boot-v2), the substitution for `IDF_TARGET_SBV2_KEY` renders the "default" field even if the target (esp32c6 or esp32h2 or esp32p4) is specified.

For the current regex to correctly substitute the target, either, we can change the string in docs to:

> {IDF_TARGET_SBV2_KEY:default="RSA-3072", esp32c2="ECDSA-256 or ECDSA-192", esp32c6="RSA-3072, ECDSA-256, or ECDSA-192", esp32h2="RSA-3072, ECDSA-256, or ECDSA-192", esp32p4="RSA-3072, ECDSA-256, or ECDSA-192"}

that is, re-write all the key algorithms for all the targets, or just update the regex in the `esp-docs`.

IMO rewriting would just keep bulking up the string for more future targets whereas if we update the regex itself then we would just need to add a small entry (`or {target_name}`) for every new target as done [here](https://github.com/espressif/esp-idf/commit/f46a93e565476d3b123de66780461225e5d20e13#diff-9f8b399d56411e55391140d7e57cc38d8233c0c20f8e56181589dd8874906721).
